### PR TITLE
Fix unable to load library in Angular

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web-eid/web-eid-library",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "",
   "scripts": {
     "lint": "eslint",
@@ -18,13 +18,6 @@
     "url": "git@github.com:web-eid/web-eid.js.git"
   },
   "module": "web-eid.js",
-  "exports": {
-    ".": {
-      "browser": "./dist/iife/web-eid.min.js",
-      "import": "./web-eid.js",
-      "default": "./dist/iife/web-eid.min.js"
-    }
-  },
   "files": [
     "config.d.ts",
     "config.d.ts.map",

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@
  */
 
 export default Object.freeze({
-  VERSION:                          "2.0.2",
+  VERSION:                          "2.1.0",
   EXTENSION_HANDSHAKE_TIMEOUT:      1000,          // 1 second
   NATIVE_APP_HANDSHAKE_TIMEOUT:     5 * 1000,      // 5 seconds
   DEFAULT_USER_INTERACTION_TIMEOUT: 2 * 60 * 1000, // 2 minutes


### PR DESCRIPTION
Error: Uncaught SyntaxError: The requested module 'http://localhost:4200/@fs/home/....../web-eid-angular-example/.angular/cache/19.1.7/web-eid-angular-example/vite/deps/@web-eid_web-eid-library.js?v=ba44c02a' doesn't provide an export named: 'default'

WE2-1048
