### PR TITLE
Fix source map resolution for bundlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ When using a build tool like WebPack, Babel, Rollup or the TypeScript compiler:
 
 ```javascript
 // Import the Web-eID library
-import * as webeid from '@web-eid/web-eid-library/web-eid';
+import * as webeid from '@web-eid/web-eid-library';
 
 // ...or only what you need
 import {
@@ -258,7 +258,7 @@ import {
   authenticate,
   Action,
   ErrorCode
-} from '@web-eid/web-eid-library/web-eid';
+} from '@web-eid/web-eid-library';
 
 
 // If you need TypeScript interfaces, they are also available!
@@ -913,12 +913,6 @@ npm link ~/workspace/web-eid-library
 **Pros**  
 - This option might be more convenient for active development.
 - After making changes to the Web-eID library source and rebuilding the library project, you don't need to reinstall the dependency in your other project.
-
-**Cons**  
-- ES modules are located at `web-eid/dist/node/` instead of directly under `web-eid/`.
-  ```ts
-  import AuthenticateOptions from 'web-eid/dist/node/models/AuthenticateOptions';
-  ```
 
 #### Using `npm pack`
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     ".": {
       "types": "./dist/node/web-eid.d.ts",
       "import": "./dist/node/web-eid.js",
-      "require": "./dist/umd/web-eid.cjs"
+      "require": "./dist/umd/web-eid.cjs",
+      "default": "./dist/umd/web-eid.cjs"
     },
     "./config": {
       "types": "./dist/node/config.d.ts",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,45 @@
     "type": "git",
     "url": "git@github.com:web-eid/web-eid.js.git"
   },
-  "module": "web-eid.js",
+  "main": "dist/node/web-eid.js",
+  "module": "dist/node/web-eid.js",
+  "types": "dist/node/web-eid.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/web-eid.d.ts",
+      "import": "./dist/node/web-eid.js"
+    },
+    "./config": {
+      "types": "./dist/node/config.d.ts",
+      "import": "./dist/node/config.js"
+    },
+    "./errors/*": {
+      "types": "./dist/node/errors/*.d.ts",
+      "import": "./dist/node/errors/*.js"
+    },
+    "./models/*": {
+      "types": "./dist/node/models/*.d.ts",
+      "import": "./dist/node/models/*.js"
+    },
+    "./models/message/*": {
+      "types": "./dist/node/models/message/*.d.ts",
+      "import": "./dist/node/models/message/*.js"
+    },
+    "./services/*": {
+      "types": "./dist/node/services/*.d.ts",
+      "import": "./dist/node/services/*.js"
+    },
+    "./utils/*": {
+      "types": "./dist/node/utils/*.d.ts",
+      "import": "./dist/node/utils/*.js"
+    }
+  },
   "files": [
+    "src/**/*",
+    "dist/node/**/*",
+    "dist/es/*",
+    "dist/iife/*",
+    "dist/umd/*",
     "config.d.ts",
     "config.d.ts.map",
     "config.js",
@@ -30,12 +67,8 @@
     "errors/**/*",
     "models/**/*",
     "services/**/*",
-    "utils/**/*",
-    "dist/es/*",
-    "dist/iife/*",
-    "dist/umd/*"
+    "utils/**/*"
   ],
-  "types": "web-eid.d.ts",
   "author": "Tanel Metsar",
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,13 +17,15 @@
     "type": "git",
     "url": "git@github.com:web-eid/web-eid.js.git"
   },
-  "main": "dist/node/web-eid.js",
+  "type": "module",
+  "main": "dist/umd/web-eid.js",
   "module": "dist/node/web-eid.js",
   "types": "dist/node/web-eid.d.ts",
   "exports": {
     ".": {
       "types": "./dist/node/web-eid.d.ts",
-      "import": "./dist/node/web-eid.js"
+      "import": "./dist/node/web-eid.js",
+      "require": "./dist/umd/web-eid.js"
     },
     "./config": {
       "types": "./dist/node/config.d.ts",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "url": "git@github.com:web-eid/web-eid.js.git"
   },
   "type": "module",
-  "main": "dist/umd/web-eid.js",
+  "main": "dist/umd/web-eid.cjs",
   "module": "dist/node/web-eid.js",
   "types": "dist/node/web-eid.d.ts",
   "exports": {
     ".": {
       "types": "./dist/node/web-eid.d.ts",
       "import": "./dist/node/web-eid.js",
-      "require": "./dist/umd/web-eid.js"
+      "require": "./dist/umd/web-eid.cjs"
     },
     "./config": {
       "types": "./dist/node/config.d.ts",
@@ -50,7 +50,10 @@
     "./utils/*": {
       "types": "./dist/node/utils/*.d.ts",
       "import": "./dist/node/utils/*.js"
-    }
+    },
+    "./dist/es/*": "./dist/es/*",
+    "./dist/iife/*": "./dist/iife/*",
+    "./dist/umd/*": "./dist/umd/*"
   },
   "files": [
     "src/**/*",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -34,13 +34,13 @@ export default {
       plugins:   [terser()],
     },
     {
-      file:      "dist/umd/web-eid.js",
+      file:      "dist/umd/web-eid.cjs",
       format:    "umd",
       name:      "webeid",
       sourcemap: true,
     },
     {
-      file:      "dist/umd/web-eid.min.js",
+      file:      "dist/umd/web-eid.min.cjs",
       format:    "umd",
       name:      "webeid",
       sourcemap: false,


### PR DESCRIPTION
## Summary

Fixes "Failed to parse source map" warnings when using the library with bundlers like webpack that use source-map-loader.

The root cause was that the `module` field pointed to `web-eid.js` at package root, where source map paths (`../../src/`) were invalid after being copied from `dist/node/` by the prepack script.

## Changes

- Set `main`, `module`, and `types` to `dist/node/web-eid.js`
- Add `exports` field for clean subpath imports (e.g., `@web-eid/web-eid-library/models/ActionOptions`)
- Include `src/**/*` for source map resolution and `dist/node/**/*` for the entry points
- Update README import examples to use simpler paths
- Keep prepack/postpack for backwards compatibility with direct file imports

## Backwards Compatibility

Direct file imports like `@web-eid/web-eid-library/web-eid` still work because prepack copies files to root.

## Test Plan

- [ ] `npm run build` succeeds
- [ ] `npm pack` creates valid package
- [ ] Install in a webpack project and verify no source map warnings
- [ ] Verify imports work: `import { authenticate } from '@web-eid/web-eid-library'`
- [ ] Verify subpath imports work: `import ActionOptions from '@web-eid/web-eid-library/models/ActionOptions'`


Signed-off-by: Erko Risthein <erko@risthein.ee>
