### PR TITLE
Fix TypeError when receiving messages without action property

### DIFF
--- a/src/services/WebExtensionService.ts
+++ b/src/services/WebExtensionService.ts
@@ -44,7 +44,8 @@ export default class WebExtensionService {
   }
 
   private receive(event: { data: ExtensionResponse }): void {
-    if (!event.data?.action.startsWith("web-eid:")) return;
+    if (typeof event.data?.action !== "string") return;
+    if (!event.data.action.startsWith("web-eid:")) return;
 
     const message       = event.data;
     const suffix        = ["success", "failure", "ack"].find((s) => message.action.endsWith(s));

--- a/src/services/__tests__/WebExtensionService-test.ts
+++ b/src/services/__tests__/WebExtensionService-test.ts
@@ -35,6 +35,71 @@ describe("WebExtensionService", () => {
     jest.restoreAllMocks();
   });
 
+  describe("receive", () => {
+    it("should ignore messages with data but no action property", async () => {
+      jest.spyOn(console, "warn").mockImplementation();
+
+      window.postMessage({ someOtherProperty: "value" }, "*");
+      await new Promise((resolve) => setTimeout(resolve));
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it("should ignore messages with null data", async () => {
+      jest.spyOn(console, "warn").mockImplementation();
+
+      window.postMessage(null, "*");
+      await new Promise((resolve) => setTimeout(resolve));
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it("should ignore messages with undefined data", async () => {
+      jest.spyOn(console, "warn").mockImplementation();
+
+      window.postMessage(undefined, "*");
+      await new Promise((resolve) => setTimeout(resolve));
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it("should ignore messages with action as an object", async () => {
+      jest.spyOn(console, "warn").mockImplementation();
+
+      window.postMessage({ action: { id: "123", _t: "456" } }, "*");
+      await new Promise((resolve) => setTimeout(resolve));
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it("should ignore messages with action as an object with startsWith property", async () => {
+      jest.spyOn(console, "warn").mockImplementation();
+
+      window.postMessage({ action: { startsWith: "2022-10-12", endsWith: "2026-10-12" } }, "*");
+      await new Promise((resolve) => setTimeout(resolve));
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it("should ignore messages with action as a number", async () => {
+      jest.spyOn(console, "warn").mockImplementation();
+
+      window.postMessage({ action: 12345 }, "*");
+      await new Promise((resolve) => setTimeout(resolve));
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it("should ignore messages with action as an array", async () => {
+      jest.spyOn(console, "warn").mockImplementation();
+
+      window.postMessage({ action: ["web-eid:test"] }, "*");
+      await new Promise((resolve) => setTimeout(resolve));
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+  });
+
   describe("action web-eid:warning", () => {
     it("should log a warning from web-eid:warning message", async () => {
       jest.spyOn(console, "warn").mockImplementation();


### PR DESCRIPTION
 ## Summary

Fixes `TypeError: Cannot read properties of undefined (reading 'startsWith')` that occurs when the window receives postMessage events that have a `data` property but no `action` property.
 ## Root Cause

The condition `event.data?.action.startsWith("web-eid:")` safely handles when `event.data` is undefined, but throws when `event.data` exists and `event.data.action` is undefined.

## Fix

Add optional chaining on `action`:
```js
if (!event.data?.action?.startsWith("web-eid:")) return;
```

## Test Plan

- Added unit tests for messages with missing action property
- npm test passes (48 tests)


Signed-off-by: Erko Risthein <erko@risthein.ee>